### PR TITLE
#30 add api interactions in post route

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,14 +14,36 @@ nunjucks.configure('views', {
 });
 
 app.get('/', (req: Request, res: Response) => {
-	console.log('Hello, client has sent get request');
-	res.render('index.njk');
+	res.render('index.njk', { electedRepresentativeName: '' });
 });
 
-app.post('/', (req: Request, res: Response) => {
-	console.log('POST request received from client');
-	console.log(req.body.postcode);
-	res.render('index.njk');
+app.post('/', async (req: Request, res: Response) => {
+
+	try {
+		const response = await fetch(
+			`https://api.postcodes.io/postcodes/${req.body.postcode}`
+		);
+		const responseJson: any = await response.json();
+		const parliamentaryConstituency =
+			responseJson.result.parliamentary_constituency;
+
+		const electedRepresentativeRes = await fetch(
+			`https://members-api.parliament.uk/api/Location/Constituency/Search?searchText=${parliamentaryConstituency}&skip=0&take=20`
+		);
+		const electedRepresentativeJson: any =
+			await electedRepresentativeRes.json();
+		const electedRepresentativeName =
+			electedRepresentativeJson.items[0].value.currentRepresentation.member
+				.value.nameFullTitle;
+		res.render('index.njk', {
+			electedRepresentativeName: electedRepresentativeName,
+		});
+	} catch (error: unknown) {
+		console.error(error);
+		res.render('index.njk', {
+			electedRepresentativeName: 'There was an error!',
+		});
+	}
 });
 
 app.listen(port, () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import express, { Express, Request, Response } from 'express';
 import nunjucks from 'nunjucks';
 import bodyParser from 'body-parser';
+import { PostcodesApiResponse, MembersApiResponse } from '../types';
 
 const app: Express = express();
 const port = 8000;
@@ -18,19 +19,18 @@ app.get('/', (req: Request, res: Response) => {
 });
 
 app.post('/', async (req: Request, res: Response) => {
-
 	try {
 		const response = await fetch(
 			`https://api.postcodes.io/postcodes/${req.body.postcode}`
 		);
-		const responseJson: any = await response.json();
+		const responseJson: PostcodesApiResponse = await response.json();
 		const parliamentaryConstituency =
 			responseJson.result.parliamentary_constituency;
 
 		const electedRepresentativeRes = await fetch(
 			`https://members-api.parliament.uk/api/Location/Constituency/Search?searchText=${parliamentaryConstituency}&skip=0&take=20`
 		);
-		const electedRepresentativeJson: any =
+		const electedRepresentativeJson: MembersApiResponse =
 			await electedRepresentativeRes.json();
 		const electedRepresentativeName =
 			electedRepresentativeJson.items[0].value.currentRepresentation.member

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,19 @@
+export interface PostcodesApiResponse {
+	result: {
+		parliamentary_constituency: string;
+	};
+}
+
+export interface MembersApiResponse {
+	items: {
+		value: {
+			currentRepresentation: {
+				member: {
+					value: {
+						nameFullTitle: string;
+					};
+				};
+			};
+		};
+	}[];
+}

--- a/views/index.njk
+++ b/views/index.njk
@@ -13,6 +13,7 @@
             <input name='postcode' placeholder='Type postcode here'></input>
             <input type='submit' value='Submit'>
         </form>
+        <p style='font-style: italic'> Elected representative in that postcode: <span style='font-weight: bold; font-style: normal;'> {{electedRepresentativeName}} </span></p>
     </main>
     <footer>
         <p>&copy; 2023 Government Location Service. All rights reserved.</p>


### PR DESCRIPTION
### Feature Request link
[#30](https://github.com/orgs/alphagov/projects/65/views/1?pane=issue&itemId=29550285)

### Change description

- Add fetch request to [postcodes.io](https://postcodes.io/) to retrieve parliamentary constituency in a given postcode
- Add fetch request to [members.api](https://members-api.parliament.uk/index.html) to retrieve elected representative using parliamentary constituency.
- Add TypeScript interfaces for expected response from postcodes.io and members-api
- Add very basic in-line styling to display the elected representative clearly.